### PR TITLE
Use generic type in Select prompts on examples/20_tokio_tradeclient

### DIFF
--- a/examples/20_tokio_tradeclient/src/main.rs
+++ b/examples/20_tokio_tradeclient/src/main.rs
@@ -44,7 +44,10 @@ enum UserAction {
 }
 
 fn prompt_user_action() -> anyhow::Result<UserAction> {
-    let s = inquire::Select::new("Select an action", UserAction::iter().collect()).prompt()?;
+    let s = inquire::prompt_selection("Select an action", UserAction::iter().collect())?;
+    
+    // or perhaps we could also omit inquire here since the fn name is verbose enough
+    let s = prompt_selection("Select an action", UserAction::iter().collect())?;
     Ok(s)
 }
 

--- a/examples/20_tokio_tradeclient/src/main.rs
+++ b/examples/20_tokio_tradeclient/src/main.rs
@@ -44,10 +44,7 @@ enum UserAction {
 }
 
 fn prompt_user_action() -> anyhow::Result<UserAction> {
-    let s = inquire::prompt_selection("Select an action", UserAction::iter().collect())?;
-    
-    // or perhaps we could also omit inquire here since the fn name is verbose enough
-    let s = prompt_selection("Select an action", UserAction::iter().collect())?;
+    let s = inquire::Select::new("Select an action", UserAction::iter().collect()).prompt()?;
     Ok(s)
 }
 


### PR DESCRIPTION
Hey, creator of inquire here :)

I'm taking a look at a lot of crates using inquires in order to find the main points when using the lib so I can have a good idea of where to focus my efforts on API stabilization.

So I took the time to suggest these changes that make use of inquire's ability to receive any type that implements Display in its selection prompts. So for UserAction we can pass the whole object, meanwhile for the generated fix42 enums we can use the newtype pattern to create a new type specific to the 
prompt, which implements Display. This helps us to greatly simplify the prompt construction and avoid a serialization-deserialization cycle, at least on the strum_fix42 enum although the original fix42 definition is not something we can change I suppose.

Hope it helps!
